### PR TITLE
Remove duplicate Prysm entry from services.json

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -434,18 +434,6 @@
     ]
   },
   {
-    "name": "Prysm",
-    "website": "https://www.offchainlabs.com/prysm",
-    "source": "https://app.hex.tech/8dedcd99-17f4-49d8-944e-4857a355b90a/app/3f7d6967-3ef6-4e69-8f7b-d02d903f045b/latest",
-    "twitter": "https://x.com/prylabs",
-    "allocation": [
-      {
-        "name": "Geth",
-        "count": 6967
-      }
-    ]
-  },
-  {
     "name": "RockLogic",
     "website": "https://rocklogic.at",
     "source": "https://app.hex.tech/8dedcd99-17f4-49d8-944e-4857a355b90a/app/3f7d6967-3ef6-4e69-8f7b-d02d903f045b/latest",


### PR DESCRIPTION
## Summary
- Removes the standalone "Prysm" entry from `public/services.json` since Prysm is a product of Offchain Labs and was being double-counted as a separate service provider.

## Test plan
- [x] Validated `public/services.json` is still valid JSON
- [x] Confirmed no remaining "Prysm" references in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)